### PR TITLE
Fix task-editing form closing when selecting text

### DIFF
--- a/frontend/src/components/board/TaskCreationForm.tsx
+++ b/frontend/src/components/board/TaskCreationForm.tsx
@@ -87,7 +87,7 @@ const TaskCreationForm: React.FC<TaskCreationFormProps> = (props) => {
     onCancel()
   }
   return (
-    <ClickAwayListener onClickAway={onModuleClose}>
+    <ClickAwayListener mouseEvent="onMouseDown" touchEvent="onTouchStart" onClickAway={onModuleClose}>
       <form onSubmit={handleSubmit(handleFormSubmit)}>
         <Grid container spacing={2}>
           <Grid item xs={12}>

--- a/frontend/src/components/board/TaskEditForm.tsx
+++ b/frontend/src/components/board/TaskEditForm.tsx
@@ -132,7 +132,7 @@ const TaskEditForm: React.FC<TaskEditFormProps> = (props) => {
   }
 
   return (
-    <ClickAwayListener onClickAway={closeModule}>
+    <ClickAwayListener mouseEvent="onMouseDown" touchEvent="onTouchStart" onClickAway={closeModule}>
       <form onSubmit={handleSubmit(handleFormSubmit)}>
         <Grid container spacing={2}>
           <Grid item xs={12}>


### PR DESCRIPTION
## Changes
Fixed task-editing and task-creating forms closing when selecting text over the form window.

## Checklist (check all that apply, once you have confirmed they are OK)

- [x] **Styles:**
  1. No global styles.
  2. Root element (App component) should not have any specific styles.
  3. Utilize the MUI (Material-UI) library for styling.
  4. Prefer creating styled components using MUI or custom styling for specific classes/IDs.
  5. Define styles using `sx` prop rather than `style` prop.

- [x] **File Naming and Folder Structure:**
  1. File naming conventions: React components in PascalCase, others in camelCase
  2. Database types and api logic is handled in an `entities` directory.
  3. 'Pages' directory for primary page components handled by the router.
  4. Prefer one React component per file.

- [x] **General Guidelines:**
  1. Limit additional types/interfaces in `.tsx` files to main function props; place other types/interfaces in separate type files.
  2. Avoid unnecessary comments.
  3. Use arrow notation, e.g. `const xxx = () => {}` for defining functions.
  4. No `console.log()` in the code.
