### PR TITLE
fix bug where tickets are created second on the column

### DIFF
--- a/backend/futuboard/views/views.py
+++ b/backend/futuboard/views/views.py
@@ -89,11 +89,12 @@ def tickets_on_column(request, board_id, column_id):
             cornernote=request.data["cornernote"] if "cornernote" in request.data else "",
         )
 
-        new_ticket.save()
         same_column_tickets = Ticket.objects.filter(columnid=column_id)
         for ticket in same_column_tickets:
             ticket.order += 1
             ticket.save()
+
+        new_ticket.save()
 
         serializer = TicketSerializer(new_ticket)
         return JsonResponse(serializer.data, safe=False)


### PR DESCRIPTION
## Changes

- Fixed bug where tickets would be created second on the column, after another ticket had been dragged onto the column. 

## Checklist (check all that apply, once you have confirmed they are OK)

- [] **Styles:**
  1. No global styles.
  2. Root element (App component) should not have any specific styles.
  3. Utilize the MUI (Material-UI) library for styling.
  4. Prefer creating styled components using MUI or custom styling for specific classes/IDs.
  5. Define styles using `sx` prop rather than `style` prop.

- [] **File Naming and Folder Structure:**
  1. File naming conventions: React components in PascalCase, others in camelCase
  2. Database types and api logic is handled in an `entities` directory.
  3. 'Pages' directory for primary page components handled by the router.
  4. Prefer one React component per file.

- [] **General Guidelines:**
  1. Limit additional types/interfaces in `.tsx` files to main function props; place other types/interfaces in separate type files.
  2. Avoid unnecessary comments.
  3. Use arrow notation, e.g. `const xxx = () => {}` for defining functions.
  4. No `console.log()` in the code.
