### PR TITLE
Add E2E test for changing board password

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -183,6 +183,24 @@ describe("In a board", () => {
     cy.get('input[name="cornerNote"').should("have.value", taskTemplate.cornerNote)
     cy.get(`input[type="radio"][value="${taskTemplate.color}"]`).should("be.checked")
   })
+
+  it("can change board password", () => {
+    cy.get('[data-testid="MoreVertIcon"]').click()
+    cy.get("li").contains("Change Board Password").click()
+
+    cy.contains("Enter a New Password").should("be.visible")
+    cy.get('[name="old_password"]').type("alpha123")
+    cy.get('[name="new_password"]').type("newPassword")
+    cy.get('[name="confirm_password"]').type("newPassword")
+    cy.get("button").contains("Submit").click()
+    cy.contains("Enter a New Password").should("not.exist")
+
+    cy.get("li").contains("Change Board Password").click()
+
+    cy.get('[name="old_password"]').clear().type("alpha123")
+    cy.get("button").contains("Submit").click()
+    cy.contains("The old password is incorrect").should("be.visible")
+  })
 })
 
 describe("When using board templates", () => {


### PR DESCRIPTION
## Changes

- Added a new E2E test for password change

- [x] **Styles:**
  1. No global styles.
  2. Root element (App component) should not have any specific styles.
  3. Utilize the MUI (Material-UI) library for styling.
  4. Prefer creating styled components using MUI or custom styling for specific classes/IDs.
  5. Define styles using `sx` prop rather than `style` prop.

- [x] **File Naming and Folder Structure:**
  1. File naming conventions: React components in PascalCase, others in camelCase
  2. Database types and api logic is handled in an `entities` directory.
  3. 'Pages' directory for primary page components handled by the router.
  4. Prefer one React component per file.

- [x] **General Guidelines:**
  1. Limit additional types/interfaces in `.tsx` files to main function props; place other types/interfaces in separate type files.
  2. Avoid unnecessary comments.
  3. Use arrow notation, e.g. `const xxx = () => {}` for defining functions.
  4. No `console.log()` in the code.
