### PR TITLE
Sanitize json filename

### DIFF
--- a/backend/futuboard/views/import_export_views.py
+++ b/backend/futuboard/views/import_export_views.py
@@ -24,6 +24,7 @@ from rest_framework.decorators import api_view
 from django.http import JsonResponse
 import json
 from django.db import models
+from django.template.defaultfilters import slugify
 
 
 @api_view(["GET"])
@@ -34,7 +35,7 @@ def export_board_data(request, board_id):
     if request.method == "GET":
         data = create_data_dict_from_board(board_id)
         response = JsonResponse(data, safe=False)
-        filename = data["board"]["title"].replace(" ", "-") + "-" + datetime.now().strftime("%d-%m-%Y")
+        filename = slugify(data["board"]["title"] + "-" + datetime.now().strftime("%d-%m-%Y"))
         response["Content-Disposition"] = f'attachment; filename="{filename}.json"'
 
         return response

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -195,7 +195,7 @@ describe("When exporting and/or importing a board", () => {
     const dateString = date
       .toLocaleString("fr-FR", { day: "2-digit", month: "2-digit", year: "numeric" })
       .replace(/[^a-zA-Z0-9]/g, "-")
-    const fileName = `${defaultBoard.title.replace(/\s/g, "-")}-${dateString}.json`
+    const fileName = `${defaultBoard.title.replace(/\s/g, "-").toLowerCase()}-${dateString}.json`
     const filePath = `downloads/${fileName}`
 
     cy.readFile(filePath).should("exist")


### PR DESCRIPTION
## Changes
- Sanitize JSON filenames

## Checklist (check all that apply, once you have confirmed they are OK)

- [x] **Styles:**
  1. No global styles.
  2. Root element (App component) should not have any specific styles.
  3. Utilize the MUI (Material-UI) library for styling.
  4. Prefer creating styled components using MUI or custom styling for specific classes/IDs.
  5. Define styles using `sx` prop rather than `style` prop.

- [x] **File Naming and Folder Structure:**
  1. File naming conventions: React components in PascalCase, others in camelCase
  2. Database types and api logic is handled in an `entities` directory.
  3. 'Pages' directory for primary page components handled by the router.
  4. Prefer one React component per file.

- [x] **General Guidelines:**
  1. Limit additional types/interfaces in `.tsx` files to main function props; place other types/interfaces in separate type files.
  2. Avoid unnecessary comments.
  3. Use arrow notation, e.g. `const xxx = () => {}` for defining functions.
  4. No `console.log()` in the code.
