### PR TITLE
Fix burnup done calculation

### DIFF
--- a/backend/futuboard/views/chartViews.py
+++ b/backend/futuboard/views/chartViews.py
@@ -72,23 +72,30 @@ def burn_up(request: rest_framework.request.Request, board_id, scope_id):
 
         data = []
 
-        len_diff = len(done_data_with_column_ids) - len(scope_data_with_column_ids)
+        len_done = len(done_data_with_column_ids)
+        len_scope = len(scope_data_with_column_ids)
+
+        # Pad the shorter list, so both start at same date, so that dates match up (end date is always the same, i.e., the current date)
+        if len_done > len_scope:
+            len_diff = len_done - len_scope
+            scope_data_with_column_ids = [(None, {})] * len_diff + scope_data_with_column_ids
+        elif len_scope > len_done:
+            len_diff = len_scope - len_done
+            done_data_with_column_ids = [(None, {})] * len_diff + done_data_with_column_ids
 
         for i in range(len(done_data_with_column_ids)):
             scope_size = 0
             done_size = 0
 
-            scope_index = i - len_diff
-            if scope_index >= 0:
-                scope_column_data = scope_data_with_column_ids[scope_index][1]
-                for column_id in scope_column_data:
-                    scope_size += scope_column_data[column_id]
+            (timestamp_scope, scope_column_data) = scope_data_with_column_ids[i]
+            for column_id in scope_column_data:
+                scope_size += scope_column_data[column_id]
 
-            done_column_data = done_data_with_column_ids[i][1]
+            (timestamp_done, done_column_data) = done_data_with_column_ids[i]
             for column_id in done_column_data:
                 done_size += done_column_data[column_id]
 
-            timestamp = done_data_with_column_ids[i][0]
+            timestamp = timestamp_scope if timestamp_scope is not None else timestamp_done
 
             data.append({"name": timestamp, "scope": scope_size, "done": done_size})
 

--- a/backend/futuboard/views/chartViews.py
+++ b/backend/futuboard/views/chartViews.py
@@ -61,19 +61,35 @@ def burn_up(request: rest_framework.request.Request, board_id, scope_id):
 
         columns = Column.objects.filter(boardid=board_id).order_by("ordernum")
 
-        data_with_column_ids = get_column_sizes_at_times(columns, time_unit, count_unit, scope_id=scope_id)
+        done_columns = scope.done_columns.all()
 
-        done_column_ids = [str(column.columnid) for column in scope.done_columns.all()]
+        tickets_in_scope = scope.tickets.all()
+
+        scope_data_with_column_ids = get_column_sizes_at_times(columns, time_unit, count_unit, scope_id=scope_id)
+        done_data_with_column_ids = get_column_sizes_at_times(
+            done_columns, time_unit, count_unit, tickets=tickets_in_scope
+        )
 
         data = []
 
-        for timestamp, column_data in data_with_column_ids:
+        len_diff = len(done_data_with_column_ids) - len(scope_data_with_column_ids)
+
+        for i in range(len(done_data_with_column_ids)):
             scope_size = 0
             done_size = 0
-            for column_id in column_data:
-                if column_id in done_column_ids:
-                    done_size += column_data[column_id]
-                scope_size += column_data[column_id]
+
+            scope_index = i - len_diff
+            if scope_index >= 0:
+                scope_column_data = scope_data_with_column_ids[scope_index][1]
+                for column_id in scope_column_data:
+                    scope_size += scope_column_data[column_id]
+
+            done_column_data = done_data_with_column_ids[i][1]
+            for column_id in done_column_data:
+                done_size += done_column_data[column_id]
+
+            timestamp = done_data_with_column_ids[i][0]
+
             data.append({"name": timestamp, "scope": scope_size, "done": done_size})
 
         return JsonResponse({"data": data}, safe=False)
@@ -106,14 +122,18 @@ def velocity(request: rest_framework.request.Request, board_id):
         return JsonResponse({"data": data}, safe=False)
 
 
-def get_column_sizes_at_times(columns, time_unit, count_unit, start_time=None, end_time=None, scope_id=None):
+def get_column_sizes_at_times(
+    columns, time_unit, count_unit, start_time=None, end_time=None, scope_id=None, tickets=None
+):
     event_in_columns = Q(old_columnid__in=columns) | Q(new_columnid__in=columns)
-    event_in_scope = Q(old_scopes__in=[scope_id]) | Q(new_scopes__in=[scope_id])
+    event_in_scope = Q(old_scopes__in=[scope_id]) | Q(new_scopes__in=[scope_id]) if scope_id else Q()
+    event_has_ticket = Q(ticketid__in=tickets) if tickets else Q()
 
-    if scope_id is not None:
-        ticket_events = TicketEvent.objects.filter(event_in_columns & event_in_scope).order_by("event_time").distinct()
-    else:
-        ticket_events = TicketEvent.objects.filter(event_in_columns).order_by("event_time").distinct()
+    ticket_events = (
+        TicketEvent.objects.filter(event_in_columns & event_in_scope & event_has_ticket)
+        .order_by("event_time")
+        .distinct()
+    )
 
     if len(ticket_events) == 0:
         return []
@@ -152,7 +172,8 @@ def get_column_sizes_at_times(columns, time_unit, count_unit, start_time=None, e
     final_data = []
 
     def setSize(column_sizes, columnid, change):
-        column_sizes[str(columnid)] += change
+        if column_sizes.get(str(columnid)) is not None:
+            column_sizes[str(columnid)] += change
 
     time = start_time
     can_have_events_before_start_time = earliest_event_time < start_time

--- a/backend/tests/test_chartviews.py
+++ b/backend/tests/test_chartviews.py
@@ -484,13 +484,13 @@ def test_burn_up():
     ticket_done = create_ticket_at_time(boardid, other_column, creation_time_1, size=3)
     ticket_always_in_done = create_ticket_at_time(boardid, done_column, creation_time_1, size=2)
 
-    freezer = freeze_time("2024-01-01")  # Scope 16, Done 0
+    freezer = freeze_time("2024-01-01")  # Scope 16, Done 2
     freezer.start()
     api_client.post(reverse("tickets_in_scope", args=[scope_id]), {"ticketid": ticket_not_done["ticketid"]})
     api_client.post(reverse("tickets_in_scope", args=[scope_id]), {"ticketid": ticket_removed_from_scope["ticketid"]})
     freezer.stop()
 
-    freezer = freeze_time("2024-01-02")  # Scope 19, Done 0
+    freezer = freeze_time("2024-01-02")  # Scope 19, Done 2
     freezer.start()
     api_client.post(reverse("tickets_in_scope", args=[scope_id]), {"ticketid": ticket_done["ticketid"]})
     freezer.stop()
@@ -525,8 +525,8 @@ def test_burn_up():
     assert len(data) == 5
 
     assert data == [
-        {"name": "2024-01-01T00:00:00", "scope": 16, "done": 0},
-        {"name": "2024-01-02T00:00:00", "scope": 19, "done": 0},
+        {"name": "2024-01-01T00:00:00", "scope": 16, "done": 2},
+        {"name": "2024-01-02T00:00:00", "scope": 19, "done": 2},
         {"name": "2024-01-03T00:00:00", "scope": 21, "done": 2},
         {"name": "2024-01-04T00:00:00", "scope": 15, "done": 5},
         {"name": "2024-01-05T00:00:00", "scope": 15, "done": 5},

--- a/frontend/src/components/charts/BurnUpChart.tsx
+++ b/frontend/src/components/charts/BurnUpChart.tsx
@@ -105,8 +105,8 @@ const BurnUpChart: React.FC<BurnUpChartProps> = ({ boardId }) => {
                 />
               )}
             />
-            <Line type="linear" dataKey="scope" stroke="#03a9f4" fill="#03a9f4" />
-            <Line type="linear" dataKey="done" fill="#f44336" stroke="#f44336" />
+            <Line type="linear" dataKey="scope" stroke="#03a9f4" fill="#03a9f4" dot={false} strokeWidth={2} />
+            <Line type="linear" dataKey="done" fill="#f44336" stroke="#f44336" dot={false} strokeWidth={2} />
           </LineChart>
         </ChartContainer>
       )}


### PR DESCRIPTION
## Changes
- Fixed burnup done calculation, so that tickets are shown as done when they were moved to the done column, irrespective of if they were in the scope back then or not.
- Remove dots from burnup chart
![image](https://github.com/user-attachments/assets/b69ad7a5-c146-47ae-b5ad-4fd5785e5152)


## Checklist (check all that apply, once you have confirmed they are OK)

- [] **Styles:**
  1. No global styles.
  2. Root element (App component) should not have any specific styles.
  3. Utilize the MUI (Material-UI) library for styling.
  4. Prefer creating styled components using MUI or custom styling for specific classes/IDs.
  5. Define styles using `sx` prop rather than `style` prop.

- [] **File Naming and Folder Structure:**
  1. File naming conventions: React components in PascalCase, others in camelCase
  2. Database types and api logic is handled in an `entities` directory.
  3. 'Pages' directory for primary page components handled by the router.
  4. Prefer one React component per file.

- [] **General Guidelines:**
  1. Limit additional types/interfaces in `.tsx` files to main function props; place other types/interfaces in separate type files.
  2. Avoid unnecessary comments.
  3. Use arrow notation, e.g. `const xxx = () => {}` for defining functions.
  4. No `console.log()` in the code.
